### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "bumpVersion": "patch",
   "extends": [
     "config:best-practices",
     ":semanticCommits",


### PR DESCRIPTION
This pull request includes a small change to the `renovate.json` file. The change adds a new configuration setting to bump the version as a patch.

* [`renovate.json`](diffhunk://#diff-7b5c8955fc544a11b4b74eddb4115f9cc51c9cf162dbffa60d37eeed82a55a57R3): Added the `"bumpVersion": "patch"` configuration setting.