### PR TITLE
Fix/sitemap issue fix

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/next-sitemap.config.mjs
+++ b/next-sitemap.config.mjs
@@ -1,6 +1,7 @@
 /** @type {import('next-sitemap').IConfig} */
-module.exports = {
+export default {
   siteUrl: process.env.SITE_URL || 'https://ckomop0x.me',
   generateRobotsTxt: true, // (optional),
+  exclude: ['/poetry-test', '/test'], // (optional),
   outDir: './out',
 };

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "predev": "npm run gen",
     "dev": "next dev -p 8000",
     "build": "next build",
-    "postbuild": "next-sitemap",
+    "postbuild": "next-sitemap --config next-sitemap.config.mjs",
     "start": "next start",
     "test": "vitest run --passWithNoTests",
     "test:coverage": "vitest run --passWithNoTests --coverage",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ckomop0x-me-site",
-  "version": "7.1.6",
+  "version": "7.1.7",
   "description": "Pavel Klochkov personal blog — ckomop0x.me",
   "keywords": [
     "nextjs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,10 @@
     "target": "esnext",
     "module": "commonjs",
     "moduleResolution": "Node",
-    "lib": ["dom", "es2019"],
+    "lib": [
+      "dom",
+      "es2019"
+    ],
     "allowJs": true,
     "jsx": "preserve",
     "strict": true,
@@ -15,18 +18,32 @@
     "noEmit": true,
     "skipLibCheck": true,
     "paths": {
-      "@/*": ["*"]
+      "@/*": [
+        "*"
+      ]
     },
     "plugins": [
       {
         "name": "ts-graphql-plugin"
+      },
+      {
+        "name": "next"
       }
     ],
-    "typeRoots": ["./types", "./node_modules/@types"],
+    "typeRoots": [
+      "./types",
+      "./node_modules/@types"
+    ],
     "forceConsistentCasingInFileNames": true,
     "isolatedModules": true,
     "incremental": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"],
-  "exclude": ["node_modules"]
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
This pull request includes several changes to the configuration and package files to update the site version, rename the sitemap configuration file, and adjust the postbuild script. The most important changes are listed below:

Configuration updates:

* [`next-sitemap.config.mjs`](diffhunk://#diff-ffb7932b783a758aad8669b88ffb446e515ce5599266bf5eee614fabdc043081L2-R5): Renamed from `next-sitemap.config.js` and updated the export to ES module syntax. Added exclusion of specific paths from the sitemap generation.

Package updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the site version from `7.1.6` to `7.1.7`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L26-R26): Modified the `postbuild` script to use the renamed sitemap configuration file `next-sitemap.config.mjs`.