### PR TITLE
Use shared workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Call unit tests workflow
 
 on:
   pull_request:
@@ -7,23 +7,9 @@ on:
       - main
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
-        with:
-          node-version: '22'
-      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-      - name: Run unit tests
-        run: npm run test:coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          name: codecov-umbrella
-          fail_ci_if_error: false
+  call-shared-workflow:
+    uses: ckomop0x/shared-workflows/.github/workflows/unit-tests.yml@main
+    with:
+      node_version: '22'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
This pull request updates the `.github/workflows/test.yml` file to streamline the unit testing process by replacing the local lint job with a shared workflow. The changes simplify the configuration and centralize the unit test execution.

Workflow updates:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L1-R1): Renamed the workflow from "Test" to "Call unit tests workflow" for clarity.
* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L10-L29): Replaced the local `lint` job with a `call-shared-workflow` job that uses a shared workflow (`ckomop0x/shared-workflows/.github/workflows/unit-tests.yml@main`). This change removes the steps for setting up the environment, installing dependencies, running unit tests, and uploading coverage, delegating these tasks to the shared workflow.