### PR TITLE
Fix test

### DIFF
--- a/src/utils/api/apollo-client.ts
+++ b/src/utils/api/apollo-client.ts
@@ -1,11 +1,11 @@
-import { ApolloClient, InMemoryCache } from '@apollo/client';
+import { ApolloClient, HttpLink, InMemoryCache } from '@apollo/client';
 
 import { getGraphQLUrl } from '@/utils/api/getGraphQLUrl';
 
 const graphQLUrl = getGraphQLUrl();
 
 const apolloClient = new ApolloClient({
-  uri: graphQLUrl,
+  link: new HttpLink({ uri: graphQLUrl }),
   cache: new InMemoryCache(),
 });
 


### PR DESCRIPTION
This pull request refactors how the Apollo Client is instantiated to use the recommended `HttpLink` instead of passing the `uri` directly. It also updates the related test to properly mock and verify the construction of the `HttpLink` and its usage in the `ApolloClient` setup.

**Apollo Client instantiation improvements:**

* Refactored `src/utils/api/apollo-client.ts` to construct the Apollo Client using a `HttpLink` with the `uri` set to the GraphQL URL, instead of passing the `uri` directly to the client.

**Test enhancements:**

* Updated `src/utils/api/apollo-client.test.ts` to mock the `HttpLink` constructor, verify it is called with the correct URI, and check that the resulting link instance is passed to the `ApolloClient`. Also ensured that the cache constructor is still called.